### PR TITLE
feat: add release workflow with site-gen and release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths: ['sources/**', 'metanorma.yml']
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+    paths: ['sources/**', 'metanorma.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-mn/site-gen@v1
+        with:
+          agree-to-terms: 'true'
+
+      - uses: actions-mn/release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses actions-mn/site-gen to compile and actions-mn/release to publish per-document GitHub Releases.

This repo contains CC/DIR 10002:2019 (published, ed 1). The release action will:
- Compile via site-gen → _site/ with RXL, HTML, PDF
- Discover the document from its RXL metadata
- Create GitHub Release with tag `cc-dir-10002-2019/ed1`
- Upload `cc-dir-10002-2019-ed1.zip` as release asset

After merge, add the `metanorma-release` topic to enable portal discovery.