### PR TITLE
ci: update metanorma workflows and add release manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
-    paths: ['sources/**', 'metanorma.yml']
+    paths: ['sources/**', 'metanorma.yml', 'metanorma.release.yml']
   workflow_dispatch:
 
 permissions:
@@ -11,17 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    container: docker://metanorma/metanorma
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions-mn/site-gen@v1
-        with:
-          agree-to-terms: 'true'
-          install-fonts: 'true'
-          continue-without-fonts: 'true'
-
-      - uses: actions-mn/release@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@v1
+    with:
+      default-visibility: private
+    secrets: inherit

--- a/metanorma.release.yml
+++ b/metanorma.release.yml
@@ -1,0 +1,2 @@
+documents:
+  - source: sources/cc-10002.adoc


### PR DESCRIPTION
Updates CI workflows to use shared reusable workflows from `actions-mn/.github` and adds `metanorma.release.yml` manifest.

Changes:
- `release.yml` now references `actions-mn/.github/.github/workflows/metanorma-release.yml@v1`
- Sets `default-visibility: private` (safe-by-default)
- Adds `metanorma.release.yml` listing cc-10002.adoc as public
- Adds `metanorma.release.yml` to paths trigger